### PR TITLE
feat(Provider): Simplify providers

### DIFF
--- a/src/apps/Service.ts
+++ b/src/apps/Service.ts
@@ -123,7 +123,6 @@ export class Service extends pulumi.ComponentResource {
     });
 
     this.mapping = new Mapping(`${name}-mapping`, mapping, {
-      ...opts,
       parent: this,
     });
 

--- a/src/helpers/Config.ts
+++ b/src/helpers/Config.ts
@@ -1,6 +1,9 @@
 import * as pulumi from '@pulumi/pulumi';
 const pulumiConfig = new pulumi.Config();
 
+import * as k8s from '@pulumi/kubernetes';
+import * as gcp from '@pulumi/gcp';
+
 /**
  * Config Class
  *
@@ -20,11 +23,14 @@ export class Config {
       })()
     );
   }
-  getProviderArgs<P>(key: string) {
-    return pulumi.output<P>(
-      (() => {
-        return (pulumiConfig.get(`provider-${key}`) as unknown) as P;
-      })()
-    );
+  
+  getK8SProvider(): k8s.Provider {
+    // Not implemented
+    return new k8s.Provider('k8s-provider', {});
+  }
+
+  getGCPProvider(): gcp.Provider {
+    // Not implemented
+    return new gcp.Provider('gcp-provider', {});
   }
 }

--- a/src/helpers/ResourceOptions.ts
+++ b/src/helpers/ResourceOptions.ts
@@ -29,4 +29,9 @@ export interface CustomResourceOptionsWithConfig
   config?: Config;
 }
 
+export interface ComponentResourceOptionsWithConfig
+  extends pulumi.ComponentResourceOptions {
+  config?: Config;
+}
+
 export const ResourceOptions = {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import * as ambassador from './ambassador';
 import * as apps from './apps';
 import * as helpers from './helpers';
-import * as providers from './providers';
 
-export { ambassador, apps, helpers, providers };
+export { ambassador, apps, helpers };

--- a/src/providers/fromStack/GCPProvider.ts
+++ b/src/providers/fromStack/GCPProvider.ts
@@ -1,9 +1,0 @@
-import * as gcp from '@pulumi/gcp';
-import { Config } from '../../helpers';
-import { getFromStackProviderArgs } from './getFromStackProviderArgs';
-
-/** */
-export function GCPProvider(config: Config) {
-  const args = getFromStackProviderArgs(config, 'gcp');
-  return new gcp.Provider('gcp-from-stack-provider', args);
-}

--- a/src/providers/fromStack/K8SProvider.ts
+++ b/src/providers/fromStack/K8SProvider.ts
@@ -1,8 +1,0 @@
-import * as k8s from '@pulumi/kubernetes';
-import { Config } from '../../helpers';
-import { getFromStackProviderArgs } from './getFromStackProviderArgs';
-
-export function K8SProvider(config: Config) {
-  const args = getFromStackProviderArgs(config, 'k8s');
-  return new k8s.Provider('k8s-from-stack-provider', args);
-}

--- a/src/providers/fromStack/getFromStackProviderArgs.ts
+++ b/src/providers/fromStack/getFromStackProviderArgs.ts
@@ -1,5 +1,0 @@
-import { Config } from '../../helpers/Config';
-
-export function getFromStackProviderArgs(config: Config, provider: string) {
-  return config.getProviderArgs(provider);
-}

--- a/src/providers/fromStack/index.ts
+++ b/src/providers/fromStack/index.ts
@@ -1,3 +1,0 @@
-export * from './GCPProvider';
-export * from './K8SProvider';
-export * from './getFromStackProviderArgs';

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,3 +1,0 @@
-import * as fromStack from './fromStack';
-
-export { fromStack };


### PR DESCRIPTION
Makes providers easier to handle and configure by only using Config class.

BREAKING CHANGE: This change removes all provider resources. To migrate to this, you'll have to
remove all references to pulumix.providers.*.