### PR TITLE
Service Secret

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,11 +10,13 @@
 * [DockerService](classes/dockerservice.md)
 * [Mapping](classes/mapping.md)
 * [Service](classes/service.md)
+* [ServiceSecret](classes/servicesecret.md)
 
 ### Interfaces
 
 * [DockerServiceSpec](interfaces/dockerservicespec.md)
 * [MappingSpec](interfaces/mappingspec.md)
+* [ServiceSecretSpec](interfaces/servicesecretspec.md)
 * [ServiceSpec](interfaces/servicespec.md)
 
 ### Variables

--- a/docs/classes/servicesecret.md
+++ b/docs/classes/servicesecret.md
@@ -1,0 +1,216 @@
+[@tabetalt/pulumix](../README.md) › [ServiceSecret](servicesecret.md)
+
+# Class: ServiceSecret ‹**TData**›
+
+Service Secret
+
+Create a Service Account with a defined role, creates a key
+and adds that into a Kubernetes Secret.
+
+This is typically used to create inject a Service Account
+into a pod for it to have access to other services.
+
+** The secret is stored under `credentials.json` **
+
+**`example`** 
+```typescript
+import * as pulumix from '@tabetalt/pulumix';
+const firebaseServiceSecret = new pulumix.iam.ServiceSecret('firebase', {
+ roles: [
+   'roles/cloudsql.admin'
+ ],
+})
+```
+
+## Type parameters
+
+▪ **TData**
+
+## Hierarchy
+
+* ComponentResource
+
+  ↳ **ServiceSecret**
+
+## Index
+
+### Constructors
+
+* [constructor](servicesecret.md#constructor)
+
+### Properties
+
+* [account](servicesecret.md#readonly-account)
+* [key](servicesecret.md#readonly-key)
+* [members](servicesecret.md#readonly-members)
+* [name](servicesecret.md#private-readonly-name)
+* [opts](servicesecret.md#private-optional-readonly-opts)
+* [secret](servicesecret.md#readonly-secret)
+* [urn](servicesecret.md#readonly-urn)
+
+### Methods
+
+* [getData](servicesecret.md#protected-getdata)
+* [getProvider](servicesecret.md#getprovider)
+* [initialize](servicesecret.md#protected-initialize)
+* [registerOutputs](servicesecret.md#protected-registeroutputs)
+* [isInstance](servicesecret.md#static-isinstance)
+
+## Constructors
+
+###  constructor
+
+\+ **new ServiceSecret**(`name`: string, `args`: [ServiceSecretSpec](../interfaces/servicesecretspec.md), `opts?`: pulumi.ComponentResourceOptions, `config?`: [Config](config.md)): *[ServiceSecret](servicesecret.md)*
+
+*Overrides void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`args` | [ServiceSecretSpec](../interfaces/servicesecretspec.md) |
+`opts?` | pulumi.ComponentResourceOptions |
+`config?` | [Config](config.md) |
+
+**Returns:** *[ServiceSecret](servicesecret.md)*
+
+## Properties
+
+### `Readonly` account
+
+• **account**: *Account*
+
+___
+
+### `Readonly` key
+
+• **key**: *Key*
+
+___
+
+### `Readonly` members
+
+• **members**: *pulumi.Output‹IAMMember[]›*
+
+___
+
+### `Private` `Readonly` name
+
+• **name**: *string*
+
+___
+
+### `Private` `Optional` `Readonly` opts
+
+• **opts**? : *pulumi.ComponentResourceOptions*
+
+___
+
+### `Readonly` secret
+
+• **secret**: *Secret*
+
+___
+
+### `Readonly` urn
+
+• **urn**: *Output‹URN›*
+
+*Inherited from [Service](service.md).[urn](service.md#readonly-urn)*
+
+urn is the stable logical URN used to distinctly address a resource, both before and after
+deployments.
+
+## Methods
+
+### `Protected` getData
+
+▸ **getData**(): *Promise‹TData›*
+
+*Inherited from [Service](service.md).[getData](service.md#protected-getdata)*
+
+Retrieves the data produces by [initialize].  The data is immediately available in a
+derived class's constructor after the `super(...)` call to `ComponentResource`.
+
+**Returns:** *Promise‹TData›*
+
+___
+
+###  getProvider
+
+▸ **getProvider**(`moduleMember`: string): *ProviderResource | undefined*
+
+*Inherited from [Service](service.md).[getProvider](service.md#getprovider)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`moduleMember` | string |
+
+**Returns:** *ProviderResource | undefined*
+
+___
+
+### `Protected` initialize
+
+▸ **initialize**(`args`: Inputs): *Promise‹TData›*
+
+*Inherited from [Service](service.md).[initialize](service.md#protected-initialize)*
+
+Can be overridden by a subclass to asynchronously initialize data for this Component
+automatically when constructed.  The data will be available immediately for subclass
+constructors to use.  To access the data use `.getData`.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`args` | Inputs |
+
+**Returns:** *Promise‹TData›*
+
+___
+
+### `Protected` registerOutputs
+
+▸ **registerOutputs**(`outputs?`: Inputs | Promise‹Inputs› | Output‹Inputs›): *void*
+
+*Inherited from [Service](service.md).[registerOutputs](service.md#protected-registeroutputs)*
+
+registerOutputs registers synthetic outputs that a component has initialized, usually by
+allocating other child sub-resources and propagating their resulting property values.
+
+ComponentResources can call this at the end of their constructor to indicate that they are
+done creating child resources.  This is not strictly necessary as this will automatically be
+called after the `initialize` method completes.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`outputs?` | Inputs &#124; Promise‹Inputs› &#124; Output‹Inputs› |
+
+**Returns:** *void*
+
+___
+
+### `Static` isInstance
+
+▸ **isInstance**(`obj`: any): *obj is ComponentResource*
+
+*Inherited from [Service](service.md).[isInstance](service.md#static-isinstance)*
+
+*Overrides void*
+
+Returns true if the given object is an instance of CustomResource.  This is designed to work even when
+multiple copies of the Pulumi SDK have been loaded into the same process.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`obj` | any |
+
+**Returns:** *obj is ComponentResource*

--- a/docs/interfaces/servicesecretspec.md
+++ b/docs/interfaces/servicesecretspec.md
@@ -1,0 +1,41 @@
+[@tabetalt/pulumix](../README.md) › [ServiceSecretSpec](servicesecretspec.md)
+
+# Interface: ServiceSecretSpec
+
+## Hierarchy
+
+* **ServiceSecretSpec**
+
+## Index
+
+### Properties
+
+* [accountId](servicesecretspec.md#accountid)
+* [namespace](servicesecretspec.md#optional-namespace)
+* [roles](servicesecretspec.md#roles)
+
+## Properties
+
+###  accountId
+
+• **accountId**: *pulumi.Input‹string›*
+
+The account id that is used to generate the service
+account email address and a stable unique id. It is unique within a project,
+must be 6-30 characters long, and match the regular expression `a-z`
+to comply with RFC1035. Changing this forces a new service account to be created.
+
+___
+
+### `Optional` namespace
+
+• **namespace**? : *pulumi.Input‹string›*
+
+___
+
+###  roles
+
+• **roles**: *pulumi.Input‹string[]›*
+
+The role that should be applied. Note that custom roles must be of the format
+`[projects|organizations]/{parent-name}/roles/{role-name}`.

--- a/src/apps/GRPCService.ts
+++ b/src/apps/GRPCService.ts
@@ -28,8 +28,11 @@ export interface GRPCServiceSpec {
 
   /**
    * GCP Service Account Secret Name
+   * 
+   * This can be used in combination with iam.ServiceSecret.
+   * The string is the name of the secret to attach to.
    */
-  GCPServiceAccountSecret?: pulumi.Input<string>;
+  serviceSecret?: pulumi.Input<string>;
 
   /**
    * Docker image name.
@@ -88,16 +91,16 @@ export class GRPCService extends pulumi.ComponentResource {
       version = process.env.VERSION || 'dev',
       namespace,
       env = {},
-      GCPServiceAccountSecret,
+      serviceSecret,
       image,
     } = args;
 
     const container = pulumi
-      .all([GCPServiceAccountSecret, env, ports, image, version])
+      .all([serviceSecret, env, ports, image, version])
       .apply(([secret, env, ports, image, ver]) => {
         const volumeMounts: kx.types.Container['volumeMounts'] = [];
 
-        // GCPServiceAccountSecrets
+        // serviceSecrets
         if (secret) {
           const googleAuthCredsPath = `/var/run/secret/cloud.google.com/${secret}.json`;
           env.GOOGLE_APPLICATION_CREDENTIALS = googleAuthCredsPath;

--- a/src/iam/ServiceSecret.ts
+++ b/src/iam/ServiceSecret.ts
@@ -1,0 +1,103 @@
+import * as k8s from '@pulumi/kubernetes';
+import * as gcp from '@pulumi/gcp';
+import * as pulumi from '@pulumi/pulumi';
+import { Config } from '../helpers/Config';
+
+export interface ServiceSecretSpec {
+  /**
+   * The account id that is used to generate the service
+   * account email address and a stable unique id. It is unique within a project,
+   * must be 6-30 characters long, and match the regular expression `a-z`
+   * to comply with RFC1035. Changing this forces a new service account to be created.
+   */
+  accountId: pulumi.Input<string>;
+  /**
+   * The role that should be applied. Note that custom roles must be of the format
+   * `[projects|organizations]/{parent-name}/roles/{role-name}`.
+   */
+  roles: pulumi.Input<string[]>;
+
+  namespace?: pulumi.Input<string>;
+}
+
+/**
+ * Service Secret
+ *
+ * Create a Service Account with a defined role, creates a key
+ * and adds that into a Kubernetes Secret.
+ *
+ * This is typically used to create inject a Service Account
+ * into a pod for it to have access to other services.
+ *
+ * ** The secret is stored under `credentials.json` **
+ *
+ * @example
+ * ```typescript
+ * import * as pulumix from '@tabetalt/pulumix';
+ * const firebaseServiceSecret = new pulumix.iam.ServiceSecret('firebase', {
+ *  roles: [
+ *    'roles/cloudsql.admin'
+ *  ],
+ * })
+ * ```
+ * @public
+ */
+export class ServiceSecret extends pulumi.ComponentResource {
+  private readonly name: string;
+  private readonly opts?: pulumi.ComponentResourceOptions;
+
+  readonly account: gcp.serviceAccount.Account;
+  readonly members: pulumi.Output<gcp.projects.IAMMember[]>;
+  readonly key: gcp.serviceAccount.Key;
+  readonly secret: k8s.core.v1.Secret;
+
+  constructor(
+    name: string,
+    args: ServiceSecretSpec,
+    opts?: pulumi.ComponentResourceOptions,
+    config?: Config
+  ) {
+    super('apps:service-secret', name, args, opts);
+
+    const { accountId, roles, namespace } = args;
+
+    this.account = new gcp.serviceAccount.Account(
+      `${name}-service`,
+      {
+        accountId,
+      },
+      { parent: this }
+    );
+
+    this.key = new gcp.serviceAccount.Key(
+      `${name}-key`,
+      {
+        serviceAccountId: this.account.accountId,
+      },
+      { parent: this }
+    );
+
+    this.members = pulumi.output(roles).apply((roles) =>
+      roles.map(
+        (role) =>
+          new gcp.projects.IAMMember(
+            `${name}-service`,
+            {
+              role,
+              member: this.account.email.apply((a) => `serviceAccount:${a}`),
+            },
+            { parent: this }
+          )
+      )
+    );
+
+    this.secret = new k8s.core.v1.Secret(`${name}-secret`, {
+      metadata: {
+        name: namespace,
+      },
+      data: {
+        'credentials.json': this.key.privateKey,
+      },
+    });
+  }
+}

--- a/src/iam/index.ts
+++ b/src/iam/index.ts
@@ -1,0 +1,1 @@
+export * from './ServiceSecret';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import * as ambassador from './ambassador';
 import * as apps from './apps';
 import * as helpers from './helpers';
+import * as iam from './iam';
 
-export { ambassador, apps, helpers };
+export { ambassador, apps, helpers, iam };


### PR DESCRIPTION
This adds a simpler way to create service-accounts that are automatically deployed as a Kubernetes Secret, ready to be used by deployments.