### PR TITLE
fix(ServiceSecret): Fixes references to ServiceSecret

### DIFF
--- a/src/apps/GRPCService.ts
+++ b/src/apps/GRPCService.ts
@@ -1,7 +1,7 @@
 import * as pulumi from '@pulumi/pulumi';
 import * as kx from '@pulumi/kubernetesx';
 import { Mapping, MappingSpec } from '../ambassador/Mapping';
-import { Config } from '../helpers/Config';
+import { ServiceSecret } from '../iam/ServiceSecret';
 
 export interface GRPCServiceSpec {
   /**
@@ -30,9 +30,8 @@ export interface GRPCServiceSpec {
    * GCP Service Account Secret Name
    *
    * This can be used in combination with iam.ServiceSecret.
-   * The string is the name of the secret to attach to.
    */
-  serviceSecret?: pulumi.Input<string>;
+  serviceSecret?: ServiceSecret;
 
   /**
    * Docker image name.
@@ -94,33 +93,19 @@ export class GRPCService extends pulumi.ComponentResource {
       image,
     } = args;
 
-    const container = pulumi
-      .all([serviceSecret, env, ports, image, version])
-      .apply(([secret, env, ports, image, ver]) => {
-        const volumeMounts: kx.types.Container['volumeMounts'] = [];
+    env.APP_VERSION = version;
 
-        // serviceSecrets
-        if (secret) {
-          const googleAuthCredsPath = `/var/run/secret/cloud.google.com/${secret}.json`;
-          env.GOOGLE_APPLICATION_CREDENTIALS = googleAuthCredsPath;
-          volumeMounts.push({
-            name: secret,
-            mountPath: googleAuthCredsPath,
-          });
-        }
-
-        env.APP_VERSION = ver;
-
-        return {
+    const pb = new kx.PodBuilder({
+      containers: [
+        {
           env,
           image,
           ports,
-          volumeMounts,
-        };
-      });
-
-    const pb = new kx.PodBuilder({
-      containers: [container],
+          volumeMounts: serviceSecret && [serviceSecret.secret.mount(
+            '/secrets'
+          )],
+        },
+      ],
     });
 
     this.deployment = new kx.Deployment(
@@ -141,7 +126,6 @@ export class GRPCService extends pulumi.ComponentResource {
 
     const serviceSpec = this.deployment.spec.template.spec.containers.apply(
       (containers) => {
-        // TODO: handle merging ports from args
         const ports: Record<string, number> = {};
         containers.forEach((container) => {
           if (container.ports) {

--- a/src/apps/Service.ts
+++ b/src/apps/Service.ts
@@ -3,6 +3,7 @@ import * as semver from 'semver';
 import * as kx from '@pulumi/kubernetesx';
 import { Mapping, MappingSpec } from '../ambassador/Mapping';
 import { Config } from '../helpers/Config';
+import { ServiceSecret } from '../iam/ServiceSecret';
 
 export interface ServiceSpec {
   /**
@@ -15,6 +16,13 @@ export interface ServiceSpec {
    * default to: process.env.VERSION || dev
    */
   version?: pulumi.Input<string>;
+
+  /**
+   * GCP Service Account Secret Name
+   *
+   * This can be used in combination with iam.ServiceSecret.
+   */
+  serviceSecret?: ServiceSecret;
 
   /**
    * Domain
@@ -88,6 +96,7 @@ export class Service extends pulumi.ComponentResource {
       domain = primaryDomain.apply((domain) => `${name}.${domain}`),
       env = {},
       image,
+      serviceSecret,
       mapping = {
         serviceName: `${name}-service`,
         host: domain,
@@ -107,6 +116,7 @@ export class Service extends pulumi.ComponentResource {
           env,
           image,
           ports: { http: port },
+          volumeMounts: serviceSecret ? [serviceSecret.secret.mount('/var/run/secret/cloud.google.com/')] : [],
         },
       ],
     });

--- a/src/iam/ServiceSecret.ts
+++ b/src/iam/ServiceSecret.ts
@@ -1,6 +1,6 @@
-import * as k8s from '@pulumi/kubernetes';
 import * as gcp from '@pulumi/gcp';
 import * as pulumi from '@pulumi/pulumi';
+import * as kx from '@pulumi/kubernetesx';
 import { Config } from '../helpers/Config';
 
 export interface ServiceSecretSpec {
@@ -49,7 +49,7 @@ export class ServiceSecret extends pulumi.ComponentResource {
   readonly account: gcp.serviceAccount.Account;
   readonly members: pulumi.Output<gcp.projects.IAMMember[]>;
   readonly key: gcp.serviceAccount.Key;
-  readonly secret: k8s.core.v1.Secret;
+  readonly secret: kx.Secret;
 
   constructor(
     name: string,
@@ -91,7 +91,7 @@ export class ServiceSecret extends pulumi.ComponentResource {
       )
     );
 
-    this.secret = new k8s.core.v1.Secret(
+    this.secret = new kx.Secret(
       `${name}-secret`,
       {
         metadata: {


### PR DESCRIPTION
Makes it possible to actually use ServiceSecret.

We have replaced type for ServiceSecret.
Since this functionality did not work as-is, we are not doing a major version bump. I don't expect anyone to have used it, since it didn't work.

fixes #13 